### PR TITLE
Add API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,31 @@
+install_elixir: &install_elixir
+  run:
+    name: Install Elixir
+    command: |
+      wget https://github.com/elixir-lang/elixir/releases/download/v$ELIXIR_VERSION/Precompiled.zip
+      unzip -d $HOME/elixir Precompiled.zip
+      echo 'export PATH=$HOME/elixir/bin:$PATH' >> $BASH_ENV
+
+install_cfssl: &install_cfssl
+  run:
+    name: Install CFSSL
+    command: |
+      go get -u github.com/cloudflare/cfssl/cmd/cfssl
+
 version: 2
 jobs:
   build:
     docker:
-      - image: circleci/elixir:1.6
+      - image: circleci/golang:1.8
         environment:
           MIX_ENV: test
+          ELIXIR_VERSION: 1.6.5
 
     working_directory: ~/repo
     steps:
       - checkout
-
+      - <<: *install_cfssl
+      - <<: *install_elixir
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix deps.get

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 nerves_hub_ca-*.tar
-
+/test/tmp
+/ssl

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 nerves_hub_ca-*.tar
 /test/tmp
-/ssl
+/etc

--- a/README.md
+++ b/README.md
@@ -18,16 +18,11 @@ instance started with a ca certificate and a new certificate is generated.
 
 ## Initial development environment setup
 
-Start an iex shell and lets choose a path for where we want to store the
-certificates. In this example I will use `#{File.cwd!}/ssl`.
+Start an iex shell and generate the ca root certificates and 
+api web server certificates:
 
 ```elixir
-iex> path = Path.join(File.cwd!, "ssl")
-```
-
-Next, generate the ca root certificates and api web server certificates:
-
-```elixir
+iex> path = NervesHubCA.working_dir()
 iex> NervesHubCA.InitHelper.init_ca(path)
 iex> NervesHubCA.InitHelper.init_api(path)
 ```
@@ -38,17 +33,12 @@ certificates. For example:
 ```elixir
 # config/config.exs
 
-ca_cert_store = Path.join(File.cwd!, "ssl")
-if File.dir?(ca_cert_store) do
-  ca_cert_store = Path.expand(ca_cert_store)
+working_dir = Path.join(File.cwd!, "etc/cfssl")
+if File.dir?(working_dir) do
   config :nerves_hub_ca, :api, 
-    cacertfile: Path.join(ca_cert_store, "ca.pem"),
-    certfile: Path.join(ca_cert_store, "ca-api.pem"),
-    keyfile: Path.join(ca_cert_store, "ca-api-key.pem")
-
-  config :nerves_hub_ca, :cfssl,
-    ca: Path.join(ca_cert_store, "ca.pem"),
-    ca_key: Path.join(ca_cert_store, "ca-key.pem")
+    cacertfile: Path.join(working_dir, "ca.pem"),
+    certfile: Path.join(working_dir, "ca-api.pem"),
+    keyfile: Path.join(working_dir, "ca-api-key.pem")
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,22 +2,101 @@
 
 [![CircleCI](https://circleci.com/gh/nerves-hub/nerves_hub_ca.svg?style=svg)](https://circleci.com/gh/nerves-hub/nerves_hub_ca)
 
-**TODO: Add description**
+NervesHub Certificate Authority is used to generate certificates for representing
+trusted device connections to the NervesHub API. The certificate authority
+application should be run disconnected from the public internet and only
+interface with other trusted servers.
 
-## Installation
+# Configuration
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `nerves_hub_ca` to your list of dependencies in `mix.exs`:
+NervesHubCA requires that `cfssl` is installed.
+Learn more about installing `cfssl` at https://github.com/cloudflare/cfssl
+
+NervesHubCA will bring up a supervised instance of `cfssl` and attempt to start
+a `cowboy2` HTTPS web server. Starting the web server requires that the `cfssl`
+instance started with a ca certificate and a new certificate is generated.
+
+## Initial development environment setup
+
+Start an iex shell and lets choose a path for where we want to store the
+certificates. In this example I will use `#{File.cwd!}/ssl`.
 
 ```elixir
-def deps do
-  [
-    {:nerves_hub_ca, "~> 0.1.0"}
-  ]
+iex> path = Path.join(File.cwd!, "ssl")
+```
+
+Next, generate the ca root certificates and api web server certificates:
+
+```elixir
+iex> NervesHubCA.InitHelper.init_ca(path)
+iex> NervesHubCA.InitHelper.init_api(path)
+```
+
+Finally, configure the `:nerves_hub_ca` application with the location of the
+certificates. For example: 
+
+```elixir
+# config/config.exs
+
+ca_cert_store = Path.join(File.cwd!, "ssl")
+if File.dir?(ca_cert_store) do
+  ca_cert_store = Path.expand(ca_cert_store)
+  config :nerves_hub_ca, :api, 
+    cacertfile: Path.join(ca_cert_store, "ca.pem"),
+    certfile: Path.join(ca_cert_store, "ca-api.pem"),
+    keyfile: Path.join(ca_cert_store, "ca-api-key.pem")
+
+  config :nerves_hub_ca, :cfssl,
+    ca: Path.join(ca_cert_store, "ca.pem"),
+    ca_key: Path.join(ca_cert_store, "ca-key.pem")
 end
 ```
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/nerves_hub_ca](https://hexdocs.pm/nerves_hub_ca).
+## Configuring the API webserver
 
+All options under the config `:nerves_hub_ca` `:api` are passed through when
+configuring `:cowboy`.
+
+You will need to specify a port to run the web server on
+
+```elixir
+# config/config.exs
+
+config :nerves_hub_ca, :api, 
+  port: 8443
+```
+
+For added securing, you can enable client SSL and limit requests to only trusted
+servers.
+
+config :nerves_hub_ca, :api,
+  port: 8443,
+  verify: :verify_peer,
+  fail_if_no_peer_cert: true
+
+# API
+
+* Route: `/device`
+  * Method: `POST`
+  * Parameters:
+    * `serial`: The manufacture serial number.
+
+    * Response Parameters
+      * `certificate`: The certificate.
+      * `certificate_request`: The certificate signing request.
+      * `private_key`: The private key.
+      * `sums`: Certificate checksums.
+
+  * Route: `*`
+    * All other matches are proxied to the cfssl instance.
+
+Information about API endpoints can be found in the [CFSSL Docs](https://github.com/cloudflare/cfssl/tree/master/doc/api)
+
+# Tests
+
+The NervesHubCA test suite will create a certificate authority and generate a
+trusted CA API certificate before running any of the tests. Dependents can bring
+up a clean CA by adding `NervesHubCA.InitHelper.start()` to the `test/test_helper.exs`
+file. 
+
+See `test/support/init_helper.ex` for more information.

--- a/config/cfssl/ca-config.json
+++ b/config/cfssl/ca-config.json
@@ -1,0 +1,30 @@
+{
+  "signing": {
+    "default": {
+        "expiry": "730h",
+        "usages": [
+          "signing",
+          "key encipherment"
+      ]
+    },
+    "profiles": {
+        "server": {
+            "expiry": "730h",
+            "usages": [
+                "signing",
+                "key encipherment",
+                "server auth"
+            ]
+        },
+        "client": {
+            "expiry": "730h",
+            "usages": [
+                "signing",
+                "key encipherment",
+                "client auth"
+            ]
+        }
+    }
+  }
+}
+

--- a/config/cfssl/root-ca-csr.json
+++ b/config/cfssl/root-ca-csr.json
@@ -1,0 +1,14 @@
+{
+  "CN": "NervesHub Root CA",
+  "key": {
+    "algo": "ecdsa",
+    "size": 256
+  },
+  "names": [
+    {
+      "O": "NervesHub",
+      "OU": "NervesHub Certificate Authority"
+    }
+  ]
+}
+

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,4 +27,4 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-#     import_config "#{Mix.env}.exs"
+import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,29 +2,10 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# 3rd-party users, it should be done in your "mix.exs" file.
+config :nerves_hub_ca, :cfssl,
+  ca_config: Path.expand("config/cfssl/ca-config.json"),
+  root_ca_csr: Path.expand("config/cfssl/root-ca-csr.json"),
+  port: 8888,
+  address: "127.0.0.1"
 
-# You can configure your application as:
-#
-#     config :nerves_hub_ca, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:nerves_hub_ca, :key)
-#
-# You can also configure a 3rd-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,18 +1,14 @@
 use Mix.Config
 
+working_dir = Path.join(File.cwd!(), "etc/cfssl")
+
 config :nerves_hub_ca, :api, port: 8443
 
-ca_cert_store = Path.join(File.cwd!(), "ssl")
+config :nerves_hub_ca, working_dir: working_dir
 
-if File.dir?(ca_cert_store) do
-  ca_cert_store = Path.expand(ca_cert_store)
-
+if File.dir?(working_dir) do
   config :nerves_hub_ca, :api,
-    cacertfile: Path.join(ca_cert_store, "ca.pem"),
-    certfile: Path.join(ca_cert_store, "ca-api.pem"),
-    keyfile: Path.join(ca_cert_store, "ca-api-key.pem")
-
-  config :nerves_hub_ca, :cfssl,
-    ca: Path.join(ca_cert_store, "ca.pem"),
-    ca_key: Path.join(ca_cert_store, "ca-key.pem")
+    cacertfile: Path.join(working_dir, "ca.pem"),
+    certfile: Path.join(working_dir, "ca-api.pem"),
+    keyfile: Path.join(working_dir, "ca-api-key.pem")
 end

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,18 @@
+use Mix.Config
+
+config :nerves_hub_ca, :api, port: 8443
+
+ca_cert_store = Path.join(File.cwd!(), "ssl")
+
+if File.dir?(ca_cert_store) do
+  ca_cert_store = Path.expand(ca_cert_store)
+
+  config :nerves_hub_ca, :api,
+    cacertfile: Path.join(ca_cert_store, "ca.pem"),
+    certfile: Path.join(ca_cert_store, "ca-api.pem"),
+    keyfile: Path.join(ca_cert_store, "ca-api-key.pem")
+
+  config :nerves_hub_ca, :cfssl,
+    ca: Path.join(ca_cert_store, "ca.pem"),
+    ca_key: Path.join(ca_cert_store, "ca-key.pem")
+end

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,8 @@
+use Mix.Config
+
+config :nerves_hub_ca, :api,
+  port: 8443,
+  verify: :verify_peer,
+  fail_if_no_peer_cert: true
+
+config :logger, level: :info

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+config :nerves_hub_ca, working_dir: Path.expand("test/tmp")
+
 config :nerves_hub_ca, :api,
   port: 8443,
   verify: :verify_peer,

--- a/lib/nerves_hub_ca.ex
+++ b/lib/nerves_hub_ca.ex
@@ -1,18 +1,25 @@
 defmodule NervesHubCA do
-  @moduledoc """
-  Documentation for NervesHubCA.
-  """
+  alias NervesHubCA.CFSSL
 
   @doc """
-  Hello world.
+  Create a new certificate for a device.
 
-  ## Examples
+  The supplied serial number will be stored
+  in the Organization of the Distinguished Name.
 
-      iex> NervesHubCA.hello
-      :world
-
+  Parameters:
+    `serial`: The manufacturer serial number of the device
   """
-  def hello do
-    :world
+  @spec create_device_certificate(binary) :: CFSSL.result()
+  def create_device_certificate(serial) do
+    params = %{
+      request: %{
+        hosts: [""],
+        names: [%{O: serial}],
+        CN: "NervesHub Device Certificate"
+      }
+    }
+
+    CFSSL.newcert(RootCA, params)
   end
 end

--- a/lib/nerves_hub_ca.ex
+++ b/lib/nerves_hub_ca.ex
@@ -17,9 +17,14 @@ defmodule NervesHubCA do
         hosts: [""],
         names: [%{O: serial}],
         CN: "NervesHub Device Certificate"
-      }
+      },
+      profile: "client"
     }
 
     CFSSL.newcert(RootCA, params)
+  end
+
+  def working_dir do
+    Application.get_env(:nerves_hub_ca, :working_dir, "/tmp")
   end
 end

--- a/lib/nerves_hub_ca/application.ex
+++ b/lib/nerves_hub_ca/application.ex
@@ -3,18 +3,59 @@ defmodule NervesHubCA.Application do
   # for more information on OTP Applications
   @moduledoc false
 
+  @required_api_opts [:cacertfile, :certfile, :keyfile]
+
   use Application
+
+  require Logger
 
   def start(_type, _args) do
     # List all child processes to be supervised
-    children = [
-      # Starts a worker by calling: NervesHubCA.Worker.start_link(arg)
-      # {NervesHubCA.Worker, arg},
-    ]
+    start_httpc()
+
+    api_opts = Application.get_env(:nerves_hub_ca, :api, [])
+    cfssl_opts = Application.get_env(:nerves_hub_ca, :cfssl, [])
+
+    children =
+      [
+        NervesHubCA.CFSSL.child_spec(cfssl_opts, name: RootCA)
+      ] ++ api(api_opts)
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: NervesHubCA.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  defp start_httpc() do
+    :inets.start(:httpc, profile: :nerves_hub_ca)
+
+    opts = [
+      max_sessions: 8,
+      max_keep_alive_length: 4,
+      max_pipeline_length: 4,
+      keep_alive_timeout: 5_000,
+      pipeline_timeout: 5_000
+    ]
+
+    :httpc.set_options(opts, :nerves_hub_ca)
+  end
+
+  defp api(api_opts) do
+    keys = Keyword.keys(api_opts)
+
+    if Enum.all?(@required_api_opts, &(&1 in keys)) do
+      [
+        Plug.Adapters.Cowboy2.child_spec(
+          scheme: :https,
+          plug: {NervesHubCA.Router, []},
+          options: api_opts
+        )
+      ]
+    else
+      missing = Enum.reject(@required_api_opts, &(&1 in keys))
+      Logger.debug("API Webserver disabled. Missing required https opts #{inspect(missing)}")
+      []
+    end
   end
 end

--- a/lib/nerves_hub_ca/application.ex
+++ b/lib/nerves_hub_ca/application.ex
@@ -14,11 +14,11 @@ defmodule NervesHubCA.Application do
     start_httpc()
 
     api_opts = Application.get_env(:nerves_hub_ca, :api, [])
-    cfssl_opts = Application.get_env(:nerves_hub_ca, :cfssl, [])
+    root_ca_opts = Application.get_env(:nerves_hub_ca, RootCA, [])
 
     children =
       [
-        NervesHubCA.CFSSL.child_spec(cfssl_opts, name: RootCA)
+        NervesHubCA.CFSSL.child_spec(root_ca_opts, name: RootCA)
       ] ++ api(api_opts)
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/nerves_hub_ca/cfssl.ex
+++ b/lib/nerves_hub_ca/cfssl.ex
@@ -1,0 +1,211 @@
+defmodule NervesHubCA.CFSSL do
+  use GenServer
+
+  import NervesHubCA.Utils
+
+  @port 8888
+  @address "127.0.0.1"
+  @endpoint "api/v1/cfssl"
+
+  @init_poll 200
+  @start_limit 10
+
+  @type result :: {:ok, binary} | {:error, reason :: any}
+
+  def child_spec(opts, genserver_opts) do
+    port = opts[:port] || @port
+    id = Module.concat(__MODULE__, to_string(port))
+
+    %{
+      id: id,
+      start: {__MODULE__, :start_link, [opts, genserver_opts]}
+    }
+  end
+
+  @doc """
+  Start a CFSSL Server
+
+  parameters:
+    `address`: The interface address to run cfssl on.
+    `port`: the port number the cfssl server should run on. 
+    `ca`: The path to the ca certificate file.
+    `ca_key`: The path to the ca certificate private key file.
+  """
+  @spec start_link(Keyword.t()) :: GenServer.on_start()
+  def start_link(opts, genserver_opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, genserver_opts)
+  end
+
+  @doc """
+  Return the path to the ca cert the cfssl instance is configured to use
+  """
+  @spec ca_cert(pid) :: file_path :: binary | nil
+  def ca_cert(pid) do
+    GenServer.call(pid, :ca_cert)
+  end
+
+  @doc """
+  Get the status of the cfssl instance
+  """
+  @spec status(pid) :: :starting | :ready
+  def status(pid) do
+    GenServer.call(pid, :status)
+  end
+
+  @doc """
+  https://github.com/cloudflare/cfssl/blob/master/doc/api/endpoint_init_ca.txt
+  """
+  @spec init_ca(pid, Map.t() | binary) :: result
+  def init_ca(pid, params) do
+    request(pid, :post, "init_ca", params)
+    |> decode_resp
+  end
+
+  @doc """
+  https://github.com/cloudflare/cfssl/blob/master/doc/api/endpoint_certinfo.txt
+  """
+  @spec certinfo(pid, Map.t() | binary) :: result
+  def certinfo(pid, params) do
+    request(pid, :post, "certinfo", params)
+    |> decode_resp
+  end
+
+  @doc """
+  https://github.com/cloudflare/cfssl/blob/master/doc/api/endpoint_newcert.txt
+  """
+  @spec newcert(pid, Map.t() | binary) :: result
+  def newcert(pid, params) do
+    request(pid, :post, "newcert", params)
+    |> decode_resp
+  end
+
+  def request(_, _, _, _ \\ "")
+
+  def request(pid, method, endpoint, params) when is_binary(params) do
+    GenServer.call(pid, {:request, method, endpoint, params})
+  end
+
+  def request(pid, method, endpoint, params) do
+    case Jason.encode(params) do
+      {:ok, params} -> request(pid, method, endpoint, params)
+      error -> error
+    end
+  end
+
+  def wait(pid) do
+    fun = fn fun ->
+      receive do
+        :ready ->
+          :ok
+
+        _ ->
+          send(self(), status(pid))
+          fun.(fun)
+      after
+        0 ->
+          send(self(), status(pid))
+          fun.(fun)
+      end
+    end
+
+    fun.(fun)
+  end
+
+  def init(opts) do
+    IO.inspect(opts)
+    opts = default_opts(opts)
+
+    address = opts[:address]
+    port = opts[:port]
+    ca = opts[:ca]
+    ca_key = opts[:ca_key]
+
+    {:ok, pid} =
+      MuonTrap.Daemon.start_link("cfssl", [
+        "serve",
+        "-ca",
+        ca,
+        "-ca-key",
+        ca_key,
+        "-address",
+        address,
+        "-port",
+        to_string(port)
+      ])
+
+    send(self(), :init)
+
+    {:ok,
+     %{
+       address: address,
+       port: port,
+       server: pid,
+       ca: ca,
+       ca_key: ca_key,
+       start_attempts: 0,
+       status: :starting
+     }}
+  end
+
+  def handle_call(:ca_cert, _from, s) do
+    {:reply, s.ca, s}
+  end
+
+  def handle_call(:status, _from, s) do
+    {:reply, s.status, s}
+  end
+
+  def handle_call({:request, method, endpoint, params}, _from, s) do
+    url = url(endpoint, s)
+    resp = http_request(method, url, params)
+
+    {:reply, resp, s}
+  end
+
+  def handle_info(:init, %{start_attempts: attempt} = s) when attempt <= @start_limit do
+    url = url("init_ca", s)
+    body = Jason.encode!(%{"hosts" => ["localhost"], "names" => [%{"O" => "NervesHub"}]})
+
+    s =
+      case http_request(:post, url, body) do
+        {:ok, 200, _} ->
+          %{s | status: :ready}
+
+        _resp ->
+          Process.send_after(self(), :init, @init_poll)
+          %{s | start_attempts: s.start_attempts + 1}
+      end
+
+    {:noreply, s}
+  end
+
+  def handle_info(:init, s) do
+    {:stop, :failed_to_start_cfssl, s}
+  end
+
+  defp default_opts(opts) do
+    opts
+    |> Keyword.put_new(:address, @address)
+    |> Keyword.put_new(:port, @port)
+  end
+
+  defp url(endpoint, s) do
+    "http://#{s.address}:#{s.port}/#{@endpoint}/#{endpoint}"
+  end
+
+  defp decode_resp(resp) do
+    case resp do
+      {:ok, status, body} when status >= 200 and status < 300 ->
+        case Jason.decode(body) do
+          {:ok, %{"success" => true, "result" => result}} ->
+            {:ok, result}
+
+          error ->
+            error
+        end
+
+      error ->
+        error
+    end
+  end
+end

--- a/lib/nerves_hub_ca/router.ex
+++ b/lib/nerves_hub_ca/router.ex
@@ -1,0 +1,69 @@
+defmodule NervesHubCA.Router do
+  @moduledoc """
+
+  Route: /device
+    Method: POST
+    Parameters:
+      `serial`: The manufacture serial number
+
+    Response Parameters
+      `certificate`: The certificate
+      `certificate_request`: The certificate signing request
+      `private_key`: The private key
+      `sums`: Certificate checksums 
+
+  Route: *
+    All other matches are attempted directly against the cfssl instance
+
+  For more information on the available api endpoints
+  please refer to the CFSSL api docs
+
+  https://github.com/cloudflare/cfssl/tree/master/doc/api
+  """
+
+  use Plug.Router
+
+  @plug_parsers_opts [
+    parsers: [:json],
+    pass: ["*/*"],
+    length: 160_000_000,
+    json_decoder: Jason
+  ]
+
+  plug(:match)
+  plug(:dispatch)
+
+  post "create_device_certificate" do
+    opts = Plug.Parsers.init(@plug_parsers_opts)
+    conn = Plug.Parsers.call(conn, opts)
+
+    case Map.get(conn.body_params, "serial") do
+      nil ->
+        send_resp(conn, 400, "Missing parameter: serial")
+
+      serial ->
+        {:ok, result} = NervesHubCA.create_device_certificate(serial)
+        send_resp(conn, 200, Jason.encode!(result))
+    end
+  end
+
+  match _ do
+    method = conn.method |> String.downcase() |> String.to_atom()
+    path = conn.path_info |> List.last()
+    {:ok, params, conn} = Plug.Conn.read_body(conn)
+
+    resp = NervesHubCA.CFSSL.request(RootCA, method, path, params)
+
+    resp(conn, resp)
+  end
+
+  defp resp(conn, resp) do
+    {status, body} =
+      case resp do
+        {:ok, status, body} -> {status, body}
+        {:error, reason} -> {500, inspect(reason)}
+      end
+
+    send_resp(conn, status, body)
+  end
+end

--- a/lib/nerves_hub_ca/utils.ex
+++ b/lib/nerves_hub_ca/utils.ex
@@ -1,0 +1,32 @@
+defmodule NervesHubCA.Utils do
+  @timeout 5_000
+
+  def http_request(method, url, body \\ "", http_opts \\ []) do
+    headers = [
+      {'User-Agent', 'NervesHubCA'},
+      {'Content-Type', 'application/json'}
+    ]
+
+    url = String.to_charlist(url)
+
+    http_opts =
+      http_opts
+      |> Keyword.put_new(:timeout, @timeout)
+
+    req =
+      case method do
+        :get -> {url, headers}
+        _ -> {url, headers, 'application/json', body}
+      end
+
+    resp = :httpc.request(method, req, http_opts, [], :nerves_hub_ca)
+
+    case resp do
+      {:ok, {{_, status_code, _}, _headers, body}} ->
+        {:ok, status_code, to_string(body)}
+
+      error ->
+        error
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule NervesHubCA.MixProject do
       app: :nerves_hub_ca,
       version: "0.1.0",
       elixir: "~> 1.6",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -19,11 +20,16 @@ defmodule NervesHubCA.MixProject do
     ]
   end
 
+  defp elixirc_paths(env) when env in [:test, :dev], do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
+      {:plug, "~> 1.5"},
+      {:cowboy, "~> 2.1"},
+      {:jason, "~> 1.0"},
+      {:muontrap, "~> 0.3"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,10 @@
+%{
+  "cowboy": {:hex, :cowboy, "2.4.0", "f1b72fabe9c8a5fc64ac5ac85fb65474d64733d1df52a26fad5d4ba3d9f70a9f", [:rebar3], [{:cowlib, "~> 2.3.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.3.0", "bbd58ef537904e4f7c1dd62e6aa8bc831c8183ce4efa9bd1150164fe15be4caa", [:rebar3], [], "hexpm"},
+  "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
+  "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "muontrap": {:hex, :muontrap, "0.3.1", "c157f5367b73f39efd2cf12da0ac55b8454add1798f35a1d763a6bdb3ae70e31", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug": {:hex, :plug, "1.5.1", "1ff35bdecfb616f1a2b1c935ab5e4c47303f866cb929d2a76f0541e553a58165", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.3", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
+}

--- a/test/nerves_hub_ca/api_test.exs
+++ b/test/nerves_hub_ca/api_test.exs
@@ -7,9 +7,12 @@ defmodule NervesHubCA.APITest do
   test "create device certificate" do
     serial = "123456"
 
-    {:ok, result} = NervesHubCA.create_device_certificate(serial)
+    {:ok, %{"certificate" => cert}} = NervesHubCA.create_device_certificate(serial)
 
-    cert = Map.get(result, "certificate")
+    NervesHubCA.working_dir()
+    |> Path.join("device.pem")
+    |> File.write(cert)
+
     {:ok, result} = CFSSL.certinfo(RootCA, %{certificate: cert})
 
     assert serial == get_in(result, ["subject", "organization"])

--- a/test/nerves_hub_ca/api_test.exs
+++ b/test/nerves_hub_ca/api_test.exs
@@ -1,0 +1,17 @@
+defmodule NervesHubCA.APITest do
+  use ExUnit.Case
+  doctest NervesHubCA
+
+  alias NervesHubCA.CFSSL
+
+  test "create device certificate" do
+    serial = "123456"
+
+    {:ok, result} = NervesHubCA.create_device_certificate(serial)
+
+    cert = Map.get(result, "certificate")
+    {:ok, result} = CFSSL.certinfo(RootCA, %{certificate: cert})
+
+    assert serial == get_in(result, ["subject", "organization"])
+  end
+end

--- a/test/nerves_hub_ca/router_test.exs
+++ b/test/nerves_hub_ca/router_test.exs
@@ -1,0 +1,72 @@
+defmodule NervesHubCA.RouterTest do
+  use ExUnit.Case
+  doctest NervesHubCA.Router
+
+  alias NervesHubCA.CFSSL
+  import NervesHubCA.Utils
+
+  setup_all do
+    params = %{
+      request: %{
+        hosts: ["www.nerves-hub.org"],
+        names: [%{O: "nerves-hub"}],
+        CN: "www.nerves-hub.org"
+      }
+    }
+
+    {:ok, result} = CFSSL.newcert(RootCA, params)
+
+    server_cert = Map.get(result, "certificate")
+    server_key = Map.get(result, "private_key")
+
+    server_cert_file = Path.join(NervesHubCA.InitHelper.tmp(), "server.pem")
+    server_key_file = Path.join(NervesHubCA.InitHelper.tmp(), "server-key.pem")
+
+    File.write!(server_cert_file, server_cert)
+    File.write!(server_key_file, server_key)
+
+    [
+      http_opts: [
+        ssl: [
+          verify: :verify_peer,
+          cacertfile: CFSSL.ca_cert(RootCA),
+          certfile: server_cert_file,
+          keyfile: server_key_file,
+          server_name_indication: 'ca.nerves-hub.org'
+        ]
+      ],
+      params: params
+    ]
+  end
+
+  test "can create device certificates", context do
+    url = url("create_device_certificate")
+
+    params = %{
+      serial: "12345"
+    }
+
+    params = Jason.encode!(params)
+    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
+  end
+
+  test "can match cfssl paths", context do
+    url = url("newcert")
+    params = Jason.encode!(context[:params])
+    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
+  end
+
+  test "can reject fake paths", context do
+    url = url("fake")
+    assert {:ok, 404, _body} = http_request(:get, url, "", context[:http_opts])
+  end
+
+  test "return error is missing client ssl" do
+    url = url("newcert")
+    assert {:error, _reason} = http_request(:post, url, "")
+  end
+
+  defp url(endpoint) do
+    "https://localhost:8443/" <> endpoint
+  end
+end

--- a/test/nerves_hub_ca/router_test.exs
+++ b/test/nerves_hub_ca/router_test.exs
@@ -19,8 +19,8 @@ defmodule NervesHubCA.RouterTest do
     server_cert = Map.get(result, "certificate")
     server_key = Map.get(result, "private_key")
 
-    server_cert_file = Path.join(NervesHubCA.InitHelper.tmp(), "server.pem")
-    server_key_file = Path.join(NervesHubCA.InitHelper.tmp(), "server-key.pem")
+    server_cert_file = Path.join(NervesHubCA.working_dir(), "server.pem")
+    server_key_file = Path.join(NervesHubCA.working_dir(), "server-key.pem")
 
     File.write!(server_cert_file, server_cert)
     File.write!(server_key_file, server_key)

--- a/test/nerves_hub_ca_test.exs
+++ b/test/nerves_hub_ca_test.exs
@@ -1,8 +1,0 @@
-defmodule NervesHubCATest do
-  use ExUnit.Case
-  doctest NervesHubCA
-
-  test "greets the world" do
-    assert NervesHubCA.hello() == :world
-  end
-end

--- a/test/support/init_helper.ex
+++ b/test/support/init_helper.ex
@@ -1,0 +1,94 @@
+defmodule NervesHubCA.InitHelper do
+  @tmp Path.expand("test/tmp")
+
+  alias NervesHubCA.CFSSL
+
+  def start do
+    File.rm_rf(@tmp)
+    File.mkdir_p(@tmp)
+
+    CFSSL.wait(RootCA)
+    init_ca(@tmp)
+    init_api(@tmp)
+  end
+
+  def init_ca(path) do
+    # Create the root ca certificates
+    ca_params = %{
+      hosts: [""],
+      names: [%{O: "NervesHub", OU: "NervesHub Certificate Authority"}]
+    }
+
+    {:ok, result} = CFSSL.init_ca(RootCA, ca_params)
+
+    ca = Map.get(result, "certificate")
+    ca_key = Map.get(result, "private_key")
+
+    # Save the root certs
+    path = Path.expand(path)
+    File.mkdir(path)
+
+    ca_file = Path.join(path, "ca.pem")
+    File.write!(ca_file, ca)
+
+    ca_key_file = Path.join(path, "ca-key.pem")
+    File.write!(ca_key_file, ca_key)
+
+    cfssl_conf =
+      Application.get_env(:nerves_hub_ca, :cfssl, [])
+      |> Keyword.put(:ca, ca_file)
+      |> Keyword.put(:ca_key, ca_key_file)
+
+    Application.put_env(:nerves_hub_ca, :cfssl, cfssl_conf)
+    restart()
+  end
+
+  def init_api(path) do
+    # Create the API server certificates
+    server_params = %{
+      request: %{
+        hosts: ["ca.nerves-hub.org"],
+        names: [%{O: "nerves-hub"}],
+        CN: "ca.nerves-hub.org"
+      }
+    }
+
+    {:ok, result} = CFSSL.newcert(RootCA, server_params)
+
+    cert = Map.get(result, "certificate")
+    key = Map.get(result, "private_key")
+
+    # Save the api certs
+    path = Path.expand(path)
+    File.mkdir(path)
+
+    cert_file = Path.join(path, "ca-api.pem")
+    File.write!(cert_file, cert)
+
+    key_file = Path.join(path, "ca-api-key.pem")
+    File.write!(key_file, key)
+
+    ca_file =
+      Application.get_env(:nerves_hub_ca, :cfssl)
+      |> Keyword.get(:ca)
+
+    api_conf =
+      Application.get_env(:nerves_hub_ca, :api, [])
+      |> Keyword.put(:cacertfile, ca_file)
+      |> Keyword.put(:certfile, cert_file)
+      |> Keyword.put(:keyfile, key_file)
+
+    Application.put_env(:nerves_hub_ca, :api, api_conf)
+    restart()
+  end
+
+  def tmp() do
+    @tmp
+  end
+
+  defp restart() do
+    Application.stop(:nerves_hub_ca)
+    Application.start(:nerves_hub_ca)
+    CFSSL.wait(RootCA)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+NervesHubCA.InitHelper.start()
 ExUnit.start()


### PR DESCRIPTION
I've gone through and done the initial work for standing up the CA service. Basically, it has a supervised running instance of `cfssl` and a cowboy2 web server. The web server will proxy requests  directly through to `cfssl`. There are a handful of functions exposed in the `NervesHubCA` for convenience.