### PR TITLE
Add support for generating user and server certificates

### DIFF
--- a/config/cfssl/ca-config.json
+++ b/config/cfssl/ca-config.json
@@ -16,14 +16,22 @@
                 "server auth"
             ]
         },
-        "client": {
+        "device": {
             "expiry": "730h",
             "usages": [
                 "signing",
                 "key encipherment",
                 "client auth"
             ]
-        }
+        },
+        "user": {
+          "expiry": "730h",
+          "usages": [
+              "signing",
+              "key encipherment",
+              "client auth"
+          ]
+      }
     }
   }
 }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -11,7 +11,7 @@ config :nerves_hub_ca, :cfssl_defaults,
   ca_key: Path.join(working_dir, "ca-key.pem")
 
 config :nerves_hub_ca, :api,
-  port: 8443,
+  port: 4443,
   cacertfile: Path.join(working_dir, "ca.pem"),
   certfile: Path.join(working_dir, "ca-api.pem"),
   keyfile: Path.join(working_dir, "ca-api-key.pem")

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,11 +11,11 @@ config :nerves_hub_ca, :cfssl_defaults,
   ca_key: Path.join(working_dir, "ca-key.pem")
 
 config :nerves_hub_ca, :api,
-  port: 8443,
+  port: 4443,
   verify: :verify_peer,
   fail_if_no_peer_cert: true,
   cacertfile: Path.join(working_dir, "ca.pem"),
   certfile: Path.join(working_dir, "ca-api.pem"),
   keyfile: Path.join(working_dir, "ca-api-key.pem")
 
-config :logger, level: :info
+config :logger, level: :error

--- a/lib/nerves_hub_ca.ex
+++ b/lib/nerves_hub_ca.ex
@@ -46,4 +46,24 @@ defmodule NervesHubCA do
 
     CFSSL.newcert(RootCA, params)
   end
+
+  @doc """
+  Create a new certificate for a server.
+
+  Parameters:
+    `host`: The hostname for the server
+  """
+  @spec create_server_certificate(binary) :: CFSSL.result()
+  def create_server_certificate(host) do
+    params = %{
+      request: %{
+        hosts: [host],
+        names: [%{O: "NervesHub"}],
+        CN: host
+      },
+      profile: "server"
+    }
+
+    CFSSL.newcert(RootCA, params)
+  end
 end

--- a/lib/nerves_hub_ca.ex
+++ b/lib/nerves_hub_ca.ex
@@ -18,7 +18,30 @@ defmodule NervesHubCA do
         names: [%{O: serial}],
         CN: "NervesHub Device Certificate"
       },
-      profile: "client"
+      profile: "device"
+    }
+
+    CFSSL.newcert(RootCA, params)
+  end
+
+  @doc """
+  Create a new certificate for a user.
+
+  The supplied username will be stored
+  in the Organization of the Distinguished Name.
+
+  Parameters:
+    `username`: The username for the certificate
+  """
+  @spec create_user_certificate(binary) :: CFSSL.result()
+  def create_user_certificate(username) do
+    params = %{
+      request: %{
+        hosts: [""],
+        names: [%{O: username}],
+        CN: "NervesHub User Certificate"
+      },
+      profile: "user"
     }
 
     CFSSL.newcert(RootCA, params)

--- a/lib/nerves_hub_ca/cfssl.ex
+++ b/lib/nerves_hub_ca/cfssl.ex
@@ -133,7 +133,7 @@ defmodule NervesHubCA.CFSSL do
         to_string(port),
         "-config",
         ca_config
-      ])
+      ], [])
 
     send(self(), :init)
 

--- a/lib/nerves_hub_ca/cfssl.ex
+++ b/lib/nerves_hub_ca/cfssl.ex
@@ -121,19 +121,23 @@ defmodule NervesHubCA.CFSSL do
     ca_csr = Keyword.get(opts, :ca_csr)
 
     {:ok, pid} =
-      MuonTrap.Daemon.start_link("cfssl", [
-        "serve",
-        "-ca",
-        ca,
-        "-ca-key",
-        ca_key,
-        "-address",
-        address,
-        "-port",
-        to_string(port),
-        "-config",
-        ca_config
-      ], [])
+      MuonTrap.Daemon.start_link(
+        "cfssl",
+        [
+          "serve",
+          "-ca",
+          ca,
+          "-ca-key",
+          ca_key,
+          "-address",
+          address,
+          "-port",
+          to_string(port),
+          "-config",
+          ca_config
+        ],
+        []
+      )
 
     send(self(), :init)
 

--- a/lib/nerves_hub_ca/init_helper.ex
+++ b/lib/nerves_hub_ca/init_helper.ex
@@ -45,7 +45,7 @@ defmodule NervesHubCA.InitHelper do
     server_params = %{
       request: %{
         hosts: ["ca.nerves-hub.org"],
-        names: [%{O: "nerves-hub"}],
+        names: [%{O: "NervesHub"}],
         CN: "ca.nerves-hub.org"
       }
     }
@@ -77,12 +77,12 @@ defmodule NervesHubCA.InitHelper do
     restart()
   end
 
-  defp init_server(path) do
+  def init_server(path) do
     params = %{
       request: %{
-        hosts: ["www.nerves-hub.org"],
-        names: [%{O: "nerves-hub"}],
-        CN: "www.nerves-hub.org"
+        hosts: ["device.nerves-hub.org"],
+        names: [%{O: "NervesHub"}],
+        CN: "device.nerves-hub.org"
       }
     }
 

--- a/lib/nerves_hub_ca/router.ex
+++ b/lib/nerves_hub_ca/router.ex
@@ -51,6 +51,20 @@ defmodule NervesHubCA.Router do
     end
   end
 
+  post "create_user_certificate" do
+    opts = Plug.Parsers.init(@plug_parsers_opts)
+    conn = Plug.Parsers.call(conn, opts)
+
+    case Map.get(conn.body_params, "username") do
+      nil ->
+        send_resp(conn, 400, "Missing parameter: username")
+
+        username ->
+        {:ok, result} = NervesHubCA.create_user_certificate(username)
+        send_resp(conn, 200, Jason.encode!(result))
+    end
+  end
+
   match _ do
     method = conn.method |> String.downcase() |> String.to_atom()
     path = conn.path_info |> List.last()

--- a/lib/nerves_hub_ca/router.ex
+++ b/lib/nerves_hub_ca/router.ex
@@ -59,8 +59,22 @@ defmodule NervesHubCA.Router do
       nil ->
         send_resp(conn, 400, "Missing parameter: username")
 
-        username ->
+      username ->
         {:ok, result} = NervesHubCA.create_user_certificate(username)
+        send_resp(conn, 200, Jason.encode!(result))
+    end
+  end
+
+  post "create_server_certificate" do
+    opts = Plug.Parsers.init(@plug_parsers_opts)
+    conn = Plug.Parsers.call(conn, opts)
+
+    case Map.get(conn.body_params, "hostname") do
+      nil ->
+        send_resp(conn, 400, "Missing parameter: hostname")
+
+      hostname ->
+        {:ok, result} = NervesHubCA.create_server_certificate(hostname)
         send_resp(conn, 200, Jason.encode!(result))
     end
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,13 +1,13 @@
 %{
   "cowboy": {:hex, :cowboy, "2.4.0", "f1b72fabe9c8a5fc64ac5ac85fb65474d64733d1df52a26fad5d4ba3d9f70a9f", [:rebar3], [{:cowlib, "~> 2.3.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.3.0", "bbd58ef537904e4f7c1dd62e6aa8bc831c8183ce4efa9bd1150164fe15be4caa", [:rebar3], [], "hexpm"},
-  "distillery": {:hex, :distillery, "1.5.2", "eec18b2d37b55b0bcb670cf2bcf64228ed38ce8b046bb30a9b636a6f5a4c0080", [:mix], [], "hexpm"},
+  "distillery": {:hex, :distillery, "1.5.3", "b2f4fc34ec71ab4f1202a796f9290e068883b042319aa8c9aa45377ecac8597a", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.2", "332c649d08c18bc1ecc73b1befc68c647136de4f340b548844efc796405743bf", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
-  "muontrap": {:hex, :muontrap, "0.3.1", "c157f5367b73f39efd2cf12da0ac55b8454add1798f35a1d763a6bdb3ae70e31", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
-  "plug": {:hex, :plug, "1.6.0", "90d338a44c8cd762c32d3ea324f6728445c6145b51895403854b77f1536f1617", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "muontrap": {:hex, :muontrap, "0.4.0", "f3c48f5e2cbb89b6406d28e488fbd0da1ce0ca00af332860913999befca9688a", [:make, :mix], [{:elixir_make, "~> 0.4", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm"},
+  "plug": {:hex, :plug, "1.6.1", "c62fe7623d035020cf989820b38490460e6903ab7eee29e234b7586e9b6c91d6", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
 }

--- a/test/nerves_hub_ca/api_test.exs
+++ b/test/nerves_hub_ca/api_test.exs
@@ -17,4 +17,18 @@ defmodule NervesHubCA.APITest do
 
     assert serial == get_in(result, ["subject", "organization"])
   end
+
+  test "create user certificate" do
+    username = "test@test.com"
+
+    {:ok, %{"certificate" => cert}} = NervesHubCA.create_user_certificate(username)
+
+    NervesHubCA.Storage.working_dir()
+    |> Path.join("user.pem")
+    |> File.write(cert)
+
+    {:ok, result} = CFSSL.certinfo(RootCA, %{certificate: cert})
+
+    assert username == get_in(result, ["subject", "organization"])
+  end
 end

--- a/test/nerves_hub_ca/api_test.exs
+++ b/test/nerves_hub_ca/api_test.exs
@@ -31,4 +31,18 @@ defmodule NervesHubCA.APITest do
 
     assert username == get_in(result, ["subject", "organization"])
   end
+
+  test "create server certificate" do
+    hostname = "api.nerves-hub.org"
+
+    {:ok, %{"certificate" => cert}} = NervesHubCA.create_server_certificate(hostname)
+
+    NervesHubCA.Storage.working_dir()
+    |> Path.join("api.pem")
+    |> File.write(cert)
+
+    {:ok, result} = CFSSL.certinfo(RootCA, %{certificate: cert})
+
+    assert hostname == get_in(result, ["subject", "common_name"])
+  end
 end

--- a/test/nerves_hub_ca/router_test.exs
+++ b/test/nerves_hub_ca/router_test.exs
@@ -44,6 +44,17 @@ defmodule NervesHubCA.RouterTest do
     assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
   end
 
+  test "can create server certificates", context do
+    url = url("create_server_certificate")
+
+    params = %{
+      hostname: "api.nerves-hub.org"
+    }
+
+    params = Jason.encode!(params)
+    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
+  end
+
   test "can match cfssl paths", context do
     url = url("newcert")
 

--- a/test/nerves_hub_ca/router_test.exs
+++ b/test/nerves_hub_ca/router_test.exs
@@ -33,6 +33,17 @@ defmodule NervesHubCA.RouterTest do
     assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
   end
 
+  test "can create user certificates", context do
+    url = url("create_user_certificate")
+
+    params = %{
+      username: "test@test.com"
+    }
+
+    params = Jason.encode!(params)
+    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
+  end
+
   test "can match cfssl paths", context do
     url = url("newcert")
 
@@ -64,6 +75,6 @@ defmodule NervesHubCA.RouterTest do
   end
 
   defp url(endpoint) do
-    "https://localhost:8443/" <> endpoint
+    "https://localhost:4443/" <> endpoint
   end
 end


### PR DESCRIPTION
This PR will add two additional router endpoints

* `create_user_certificate` - Generate a new user account certificate for use with authenticating to the API. 
* `create_server_certificate` - Generate a new server side certificate for use with `api.nerves-hub.org` and `device.nerves-hub.org`