### PR TITLE
Generate device and api endpoint certs on init

### DIFF
--- a/lib/mix/tasks/nerves_hub_ca.init.ex
+++ b/lib/mix/tasks/nerves_hub_ca.init.ex
@@ -24,6 +24,8 @@ defmodule Mix.Tasks.NervesHubCa.Init do
     |> Enum.each(&File.write!(ca_cert, File.read!(&1), [:append]))
 
     gen_server_cert("ca.nerves-hub.org", path)
+    gen_server_cert("device.nerves-hub.org", path)
+    gen_server_cert("api.nerves-hub.org", path)
     gen_client_cert("ca-client", path)
   end
 


### PR DESCRIPTION
`mix nerves_hub_ca.init` is is used to generate a new set of certificates. This adds additional server certs commonly used in `nerves_hub_web`