### PR TITLE
Only support signing certificate requests and call cfssl directly

### DIFF
--- a/lib/nerves_hub_ca.ex
+++ b/lib/nerves_hub_ca.ex
@@ -3,26 +3,15 @@ defmodule NervesHubCA do
   alias NervesHubCA.Intermediate.CA
 
   @doc """
-  Create a new certificate for a device.
-
-  The supplied serial number will be stored
-  in the Organization of the Distinguished Name.
-
-  Parameters:
-    `serial`: The manufacturer serial number of the device
+  Get certificate information
+   parameters:
+    `cert`: The certificate binary.
   """
-  @spec create_device_certificate(binary) :: CFSSL.result()
-  def create_device_certificate(serial) do
-    params = %{
-      request: %{
-        hosts: [""],
-        names: [%{O: serial}],
-        CN: "NervesHub Device Certificate"
-      },
-      profile: "device"
-    }
-
-    CFSSL.newcert(CA.Device, params)
+  @spec certinfo(binary) :: CFSSL.result()
+  def certinfo(cert) do
+    cert_file = Plug.Upload.random_file!("cert")
+    File.write!(cert_file, cert)
+    CFSSL.certinfo(cert_file)
   end
 
   @doc """
@@ -51,29 +40,6 @@ defmodule NervesHubCA do
   end
 
   @doc """
-  Create a new certificate for a user.
-
-  The supplied username will be stored
-  in the Organization of the Distinguished Name.
-
-  Parameters:
-    `username`: The username for the certificate
-  """
-  @spec create_user_certificate(binary) :: CFSSL.result()
-  def create_user_certificate(username) do
-    params = %{
-      request: %{
-        hosts: [""],
-        names: [%{O: username}],
-        CN: "NervesHub User Certificate"
-      },
-      profile: "user"
-    }
-
-    CFSSL.newcert(CA.User, params)
-  end
-
-  @doc """
   Sign a user certificate.
 
   The supplied certificate will contain the usrrname
@@ -96,26 +62,6 @@ defmodule NervesHubCA do
     File.write!(csr_path, csr)
 
     CFSSL.sign(csr_path, ca_cert, ca_key, config, "user")
-  end
-
-  @doc """
-  Create a new certificate for a server.
-
-  Parameters:
-    `host`: The hostname for the server
-  """
-  @spec create_server_certificate(binary) :: CFSSL.result()
-  def create_server_certificate(host) do
-    params = %{
-      request: %{
-        hosts: [host],
-        names: [%{O: "NervesHub"}],
-        CN: host
-      },
-      profile: "server"
-    }
-
-    CFSSL.newcert(CA.Server, params)
   end
 
   defp config_dir do

--- a/lib/nerves_hub_ca/router.ex
+++ b/lib/nerves_hub_ca/router.ex
@@ -10,7 +10,7 @@ defmodule NervesHubCA.Router do
       `certificate`: The certificate
       `certificate_request`: The certificate signing request
       `private_key`: The private key
-      `sums`: Certificate checksums 
+      `sums`: Certificate checksums
 
   Route: *
     All other matches are attempted directly against the cfssl instance
@@ -37,20 +37,6 @@ defmodule NervesHubCA.Router do
     send_resp(conn, 200, "ok")
   end
 
-  post "create_device_certificate" do
-    opts = Plug.Parsers.init(@plug_parsers_opts)
-    conn = Plug.Parsers.call(conn, opts)
-
-    case Map.get(conn.body_params, "serial") do
-      nil ->
-        send_resp(conn, 400, "Missing parameter: serial")
-
-      serial ->
-        {:ok, result} = NervesHubCA.create_device_certificate(serial)
-        send_resp(conn, 200, Jason.encode!(result))
-    end
-  end
-
   post "sign_device_csr" do
     opts = Plug.Parsers.init(@plug_parsers_opts)
     conn = Plug.Parsers.call(conn, opts)
@@ -62,20 +48,6 @@ defmodule NervesHubCA.Router do
       csr ->
         csr = Base.decode64!(csr)
         {:ok, result} = NervesHubCA.sign_device_csr(csr)
-        send_resp(conn, 200, Jason.encode!(result))
-    end
-  end
-
-  post "create_user_certificate" do
-    opts = Plug.Parsers.init(@plug_parsers_opts)
-    conn = Plug.Parsers.call(conn, opts)
-
-    case Map.get(conn.body_params, "username") do
-      nil ->
-        send_resp(conn, 400, "Missing parameter: username")
-
-      username ->
-        {:ok, result} = NervesHubCA.create_user_certificate(username)
         send_resp(conn, 200, Jason.encode!(result))
     end
   end
@@ -95,37 +67,7 @@ defmodule NervesHubCA.Router do
     end
   end
 
-  post "create_server_certificate" do
-    opts = Plug.Parsers.init(@plug_parsers_opts)
-    conn = Plug.Parsers.call(conn, opts)
-
-    case Map.get(conn.body_params, "hostname") do
-      nil ->
-        send_resp(conn, 400, "Missing parameter: hostname")
-
-      hostname ->
-        {:ok, result} = NervesHubCA.create_server_certificate(hostname)
-        send_resp(conn, 200, Jason.encode!(result))
-    end
-  end
-
   match _ do
-    method = conn.method |> String.downcase() |> String.to_atom()
-    path = conn.path_info |> List.last()
-    {:ok, params, conn} = Plug.Conn.read_body(conn)
-
-    resp = NervesHubCA.CFSSL.request(NervesHubCA.Intermediate.CA.Server, method, path, params)
-
-    resp(conn, resp)
-  end
-
-  defp resp(conn, resp) do
-    {status, body} =
-      case resp do
-        {:ok, status, body} -> {status, body}
-        {:error, reason} -> {500, inspect(reason)}
-      end
-
-    send_resp(conn, status, body)
+    send_resp(conn, 404, "not found")
   end
 end

--- a/test/nerves_hub_ca/api_test.exs
+++ b/test/nerves_hub_ca/api_test.exs
@@ -2,41 +2,6 @@ defmodule NervesHubCA.APITest do
   use ExUnit.Case
   doctest NervesHubCA
 
-  alias NervesHubCA.CFSSL
-  alias NervesHubCA.Intermediate.CA.Server, as: CA
-
-  describe "create certificate pairs" do
-    test "devices" do
-      serial = "device-1234"
-
-      {:ok, %{"certificate" => cert}} = NervesHubCA.create_device_certificate(serial)
-
-      {:ok, result} = CFSSL.certinfo(CA, %{certificate: cert})
-
-      assert serial == get_in(result, ["subject", "organization"])
-    end
-
-    test "users" do
-      username = "test@test.com"
-
-      {:ok, %{"certificate" => cert}} = NervesHubCA.create_user_certificate(username)
-
-      {:ok, result} = CFSSL.certinfo(CA, %{certificate: cert})
-
-      assert username == get_in(result, ["subject", "organization"])
-    end
-
-    test "servers" do
-      hostname = "api.nerves-hub.org"
-
-      {:ok, %{"certificate" => cert}} = NervesHubCA.create_server_certificate(hostname)
-
-      {:ok, result} = CFSSL.certinfo(CA, %{certificate: cert})
-
-      assert hostname == get_in(result, ["subject", "common_name"])
-    end
-  end
-
   describe "create from CSR" do
     test "devices" do
       serial = "device-1234"
@@ -47,7 +12,7 @@ defmodule NervesHubCA.APITest do
 
       {:ok, %{"cert" => cert}} = NervesHubCA.sign_device_csr(csr)
 
-      {:ok, result} = CFSSL.certinfo(CA, %{certificate: cert})
+      {:ok, result} = NervesHubCA.certinfo(cert)
 
       assert serial == get_in(result, ["subject", "organization"])
     end
@@ -61,7 +26,7 @@ defmodule NervesHubCA.APITest do
 
       {:ok, %{"cert" => cert}} = NervesHubCA.sign_user_csr(csr)
 
-      {:ok, result} = CFSSL.certinfo(CA, %{certificate: cert})
+      {:ok, result} = NervesHubCA.certinfo(cert)
 
       assert username == get_in(result, ["subject", "organization"])
     end

--- a/test/nerves_hub_ca/router_test.exs
+++ b/test/nerves_hub_ca/router_test.exs
@@ -21,39 +21,6 @@ defmodule NervesHubCA.RouterTest do
     ]
   end
 
-  test "can create device certificates", context do
-    url = url("create_device_certificate")
-
-    params = %{
-      serial: "12345"
-    }
-
-    params = Jason.encode!(params)
-    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
-  end
-
-  test "can create user certificates", context do
-    url = url("create_user_certificate")
-
-    params = %{
-      username: "test@test.com"
-    }
-
-    params = Jason.encode!(params)
-    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
-  end
-
-  test "can create server certificates", context do
-    url = url("create_server_certificate")
-
-    params = %{
-      hostname: "api.nerves-hub.org"
-    }
-
-    params = Jason.encode!(params)
-    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
-  end
-
   describe "create from CSR" do
     test "devices", context do
       url = url("sign_device_csr")
@@ -86,21 +53,6 @@ defmodule NervesHubCA.RouterTest do
       params = Jason.encode!(params)
       assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
     end
-  end
-
-  test "can match cfssl paths", context do
-    url = url("newcert")
-
-    params = %{
-      request: %{
-        hosts: ["www.nerves-hub.org"],
-        names: [%{O: "nerves-hub"}],
-        CN: "www.nerves-hub.org"
-      }
-    }
-
-    params = Jason.encode!(params)
-    assert {:ok, 200, _body} = http_request(:post, url, params, context[:http_opts])
   end
 
   test "can reject fake paths", context do


### PR DESCRIPTION
This PR does the following
* Remove functions that create public / private key pairs and default to only accepting certificate signing requests.
* Do not call `cfssl serve` to bring up `cfssl` web servers to handle requests. Call `cfssl` directly.
* Cleans up other unused functions and tests.