### PR TITLE
Buy 1 year of time to fix issue with generalizedTime and the year 2050

### DIFF
--- a/lib/nerves_hub_ca/certificate_template.ex
+++ b/lib/nerves_hub_ca/certificate_template.ex
@@ -3,7 +3,7 @@ defmodule NervesHubCA.CertificateTemplate do
   alias X509.Certificate.{Template, Validity}
 
   @user_validity_years 1
-  @device_validity_years 31
+  @device_validity_years 30
   @serial_number_bytes 20
 
   @hash :sha256


### PR DESCRIPTION
Starting in 2019, certificate expiration dates reach the year 2050. According to [rfc5280](https://tools.ietf.org/html/rfc5280#section-4.1.2.5), validity dates that are >= 2050 need to be encoded using `GeneralizedTime ` instead of `UTCTime`. The `x509` dependency accounts for this [here](https://github.com/voltone/x509/blob/master/lib/x509/date_time.ex#L20-L24) but when this code is executed, an OTP error is received

```elixir
{:error, {:asn1, {{:invalid_choice_type, :generalizedTime}, [{:"OTP-PUB-KEY", :enc_Time, 2, [file: 'OTP-PUB-KEY.erl', line: 12875]}, {:"OTP-PUB-KEY", :enc_Validity, 2, [file: 'OTP-PUB-KEY.erl', line: 12928]}, {:"OTP-PUB-KEY", :enc_OTPTBSCertificate, 2, [file: 'OTP-PUB-KEY.erl', line: 15719]}, {:"OTP-PUB-KEY", :encode, 2, [file: 'OTP-PUB-KEY.erl', line: 1088]}, {:public_key, :der_encode, 2, [file: 'public_key.erl', line: 306]}, {:public_key, :pkix_sign, 2, [file: 'public_key.erl', line: 692]}, {X509.Certificate, :new, 5, [file: 'lib/x509/certificate.ex', line: 83]}, {NervesHubCA, :sign_device_csr, 1, [file: 'lib/nerves_hub_ca.ex', line: 27]}]}}}
```

I am unsure is this is an issue in OTP, or the code is not formatting generalized time correctly. Therefore, this PR will buy us some time until we can get it fixed by making the expiration date 30 years instead of 31.