### PR TITLE
Fix Deployment VM.args

### DIFF
--- a/rel/vm.args
+++ b/rel/vm.args
@@ -1,5 +1,5 @@
 ## Name of the node
--name ${APP_NAME}@${LOCAL_IPV4}
+-name ${APP_NAME}@127.0.0.1
 
 ## Cookie for distributed erlang
 -setcookie "${ERL_COOKIE}"


### PR DESCRIPTION
The CA doesn't cluster in production but requires the IPV4 variable to be set. Lets just set it to loopback. This fixes an issue with deploying the app.