### PR TITLE
Remove pattern match when loading apps for migration

### DIFF
--- a/lib/nerves_hub_ca/release/tasks.ex
+++ b/lib/nerves_hub_ca/release/tasks.ex
@@ -22,7 +22,7 @@ defmodule NervesHubCA.Release.Tasks do
 
   defp init(app, start_apps) do
     IO.puts("Loading nerves_hub_ca app for migrations...")
-    :ok = Application.load(app)
+    Application.load(app)
 
     IO.puts("Starting dependencies...")
     Enum.each(start_apps, &Application.ensure_all_started/1)


### PR DESCRIPTION
The app is failing to deploy because some of the application's deps are already started.