### PR TITLE
Fix prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,13 +90,10 @@ deploy: &deploy
   run:
     name: Deploy to production
     command: |
-      ecs-deploy \
-        -c $CLUSTER \
-        -n nerves-hub-ca \
-        -i nerveshub/nerves_hub_ca:$DOCKER_TAG \
-        -t 600 \
-        --enable-rollback \
-        --max-definitions 10
+      rel/scripts/ecs-deploy.sh \
+        $CLUSTER \
+        nerves-hub-ca \
+        nerveshub/nerves_hub_ca:$DOCKER_TAG
 
 send_notifications: &send_notifications
   run:

--- a/rel/scripts/ecs-deploy.sh
+++ b/rel/scripts/ecs-deploy.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 CLUSTER=$1
-SERVICE=$2
-TASK=$3
+SERVICE_NAME=$2
+IMAGE=$3
+MIN_PERCENTAGE=${4:-100}
+MAX_PERCENTAGE=${5:-200}
 
-aws ecs update-service \
-  --service $SERVICE \
-  --cluster $CLUSTER \
-  --task-definition $TASK
+if [ -z "$IMAGE" ]; then
+  echo "Please include a image to deploy."
+  exit 1
+fi
+
+echo "Deploying $SERVICE_NAME to $CLUSTER..."
+echo "================="
+ecs-deploy --cluster $CLUSTER \
+           --service-name $SERVICE_NAME \
+           --image $IMAGE \
+           --timeout 720 \
+           --min $MIN_PERCENTAGE \
+           --max $MAX_PERCENTAGE \
+           --enable-rollback \
+           --max-definitions 50
+echo "================="

--- a/rel/scripts/ecs-network-configuration.sh
+++ b/rel/scripts/ecs-network-configuration.sh
@@ -6,9 +6,8 @@ VPC=$1
 SG=$2
 
 VPCS=$(aws ec2 describe-vpcs --output json | jq ".Vpcs")
-VPC=$(echo $VPCS | jq --arg VPC $VPC '.[] | . as $vpc | .Tags[] | select(.Key == "Name" and .Value == $VPC) | $vpc.VpcId')
-
-SUBNETS=$(aws ec2 describe-subnets --filters=Name=vpc-id,Values=$VPC,Name=tag:Name,Values=*private* --output json | jq -c '[.Subnets[] | .SubnetId]')
+VPC=$(echo $VPCS | jq --arg vpc $VPC '.[] | select((.Tags[]|select(.Key=="Name")|.Value) == $vpc) | .VpcId')
+SUBNETS=$(aws ec2 describe-subnets --filters "Name=vpc-id,Values=$VPC" --output json | jq -c '[.Subnets[] | select((.Tags[]|select(.Key=="Name")|.Value) | contains("private")) | .SubnetId]')
 SECURITY_GROUPS=$(aws ec2 describe-security-groups --filters=Name=tag:Name,Values=$SG | jq -c '[.SecurityGroups[] | .GroupId ]')
 
 echo "awsvpcConfiguration={subnets=$SUBNETS,securityGroups=$SECURITY_GROUPS,assignPublicIp=DISABLED}"


### PR DESCRIPTION
The release scripts were using OR filters which was returning results for Subnets in the wrong VPC. This PR fixes the task network config and security groups and also updates the ecs-deploy script to get called from `rel/scripts` instead of directly. This was preventing deploy rollbacks from functioning properly.